### PR TITLE
feat(forms): semantic field-resolver fallback for missed CSS selectors

### DIFF
--- a/lib/field-resolver.js
+++ b/lib/field-resolver.js
@@ -1,0 +1,464 @@
+/**
+ * lib/field-resolver.js
+ *
+ * Semantic field-resolver fallback for lib/forms.js.
+ *
+ * When every CSS selector for a form field misses (broker changed its DOM),
+ * resolveField() locates the field by scoring visible inputs against a
+ * combination of signals rather than relying on a single attribute match.
+ *
+ * Design constraints:
+ *   - Pure JS, no embeddings, no external deps. The scorer runs inside the
+ *     Playwright page context via page.evaluate, so it must be closure-free:
+ *     it receives ONLY its own parameters plus browser globals. Module-level
+ *     constants (weights, threshold, regex source) are passed in as arguments,
+ *     never closed over — a closed-over reference is silently undefined once
+ *     the function is re-parsed inside the browser via new Function(src).
+ *   - Conservative by default: a wrong fill is worse than no fill. The
+ *     minimum score to accept a match is HIGH (MATCH_THRESHOLD = 5).
+ *   - Confirm / duplicate / secondary fields are NEVER a fill target. A field
+ *     whose name/id/placeholder/aria-label/label carries a confirm-class marker
+ *     (confirm, verify, re-enter, retype, repeat, again, secondary, alt, a
+ *     trailing 2 / _2 / -2) is forced to score 0 so the resolver abstains on it.
+ *     This holds the fail-safe invariant on the most common opt-out layout
+ *     (email + confirm-email): we never drop PII into the confirmation box, and
+ *     when the PRIMARY is unreadable we abstain entirely rather than mis-fill.
+ *   - Ambiguous-keyword guard from forms.js is preserved as a TIE-BREAK,
+ *     not a kill-switch: if two candidates share the same top score and
+ *     both could match an ambiguous intent, the resolver abstains.
+ *   - Selection is snapshot-consistent: the winner is chosen AND tagged with a
+ *     data-* marker inside the SAME page.evaluate that scored it, then located
+ *     and filled by that marker. This closes the check-to-use (TOCTOU) gap that
+ *     a score-then-reselect-by-index approach has when the DOM mutates between
+ *     the two round-trips.
+ *   - Only fires on miss — happy-path (exact selector hit) is unchanged.
+ *
+ * Public API:
+ *   resolveField(page, selector, value)  → Playwright Locator | null
+ *   deriveIntent(selector, value)        → intent string
+ *
+ * @module field-resolver
+ */
+
+'use strict';
+
+/**
+ * The minimum cumulative signal score required before the resolver will commit
+ * to filling a candidate element. Tune upward to reduce false positives;
+ * tune downward to increase recall on stripped-down forms.
+ *
+ * A correct hit on two independent signals ≥ 5 (e.g. type=email + autocomplete).
+ * A single weak match (placeholder substring alone = 2) stays below threshold.
+ */
+const MATCH_THRESHOLD = 5;
+
+/**
+ * Per-signal point values. Single source of truth for the scorer.
+ *
+ *   typeMatch:    type attribute matches the intent (structural, strongest)
+ *   autocomplete: explicit browser hint (nearly as strong as type)
+ *   exactName:    name/id equals a canonical token for the intent
+ *   substring:    name/id/placeholder/aria/label contains an intent token
+ *
+ * A correct hit on two independent signals (type 4 + autocomplete 3, or
+ * exactName 3 + substring 2) clears MATCH_THRESHOLD = 5.
+ *
+ * Passed into page.evaluate as an argument so the serialized scorer stays
+ * closure-free (it reads weights.* from its parameter, never a free variable).
+ *
+ * @type {{typeMatch:number, autocomplete:number, exactName:number, substring:number}}
+ */
+const SIGNAL_WEIGHTS = Object.freeze({
+  typeMatch: 4,
+  autocomplete: 3,
+  exactName: 3,
+  substring: 2,
+});
+
+/**
+ * Markers that identify a confirm / duplicate / secondary field — one that
+ * must NEVER be filled, because the user's PII belongs only in the PRIMARY
+ * field. Filling a confirmation field either leaks raw PII into the wrong box
+ * (name/phone/zip) or breaks submission outright (primary stays empty and the
+ * broker rejects on email !== confirm-email).
+ *
+ * Serialized into the page context as a string source (NEGATIVE_MARKER_SRC) so
+ * the scorer can rebuild the RegExp closure-free.
+ *
+ * Matches (case-insensitive):
+ *   - worded markers: confirm, verify, re-enter/reenter, re-type/retype, repeat,
+ *     again, secondary, second, alt, dup(licate)
+ *   - delimited duplicate index: foo_2 / foo-2
+ *   - bare trailing duplicate index foo2 (email2 / zip2 / phone2), EXCEPT when
+ *     the digit follows "v" — a version suffix (given_name_v2), which is a
+ *     legitimately renamed PRIMARY field, not a duplicate. Without this carve-out
+ *     the guard would falsely abstain on the common broker-renamed-attr case.
+ */
+// Token boundary = start-of-string or any non-letter (covers _, -, digits, end).
+// `\b` alone is wrong here: `_` is a word char, so \balt\b fails on "alt_email"
+// while the delimiter-aware form catches it AND still protects legit substrings
+// (e.g. "default"/"salt" do not match a delimiter-bounded "alt").
+const NEGATIVE_MARKER_SRC =
+  '(confirm|verif|re-?enter|re-?type|retype|repeat|secondary)'   // distinctive substrings
+  + '|(?:^|[^a-z])(again|second|alt|dup(?:licate)?)(?:[^a-z]|$)' // delimiter-bounded short tokens (dup AND duplicate)
+  + '|[_\\-]2$'                                                  // delimited duplicate index foo_2 / foo-2
+  + '|[a-uw-z]2$';                                               // bare duplicate index foo2, but not v2 (version)
+
+/**
+ * Derive the semantic intent from the original (missed) CSS selector plus the
+ * value that was going to be filled. Intent drives which signals we look for.
+ *
+ * @param {string} selector  The CSS selector that missed.
+ * @param {string} value     The value to be filled.
+ * @returns {string}  One of: email | firstName | lastName | fullName | phone
+ *                            | zip | city | state | country | generic
+ */
+function deriveIntent(selector, value) {
+  // Extract the attribute VALUES from CSS selector tokens (e.g. name="email",
+  // name*="first") to avoid false matches on the attribute NAMES themselves.
+  // e.g. `input[name*="first" i]` → attrValues = ["first"], NOT matching "name*=".
+  const attrValues = [];
+  const attrValueRe = /\[[\w-]+[*^$|~]?=["']?([^"'\]]+)/gi;
+  let m;
+  while ((m = attrValueRe.exec(selector || '')) !== null) {
+    attrValues.push(m[1].toLowerCase());
+  }
+  // Also extract type= value (e.g. type="email")
+  const typeMatch = /type=["']?([^"'\] ]+)/i.exec(selector || '');
+  const attrType = typeMatch ? typeMatch[1].toLowerCase() : '';
+
+  // Joined attr-value tokens for keyword checks
+  const attrStr = attrValues.join(' ');
+  const v = (value || '').toLowerCase();
+
+  // email: type attribute, attr-value contains "email" (substring — `_` is a
+  // word char so snake_case like user_email defeats \bemail\b), or value looks
+  // like an email address.
+  if (attrType === 'email') return 'email';
+  if (attrStr.includes('email')) return 'email';
+  if (/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) return 'email';
+
+  // phone: attr-value or selector token (snake/dash tolerant)
+  if (/phone|mobile|\bcell\b|\btel\b/.test(attrStr)) return 'phone';
+  if (/\btel\b/.test((selector || '').toLowerCase())) return 'phone';
+
+  // name fragments — check before fullName; order matters. `_`/`-`/space
+  // tolerant so first_name / first-name / "first name" all resolve.
+  if (/first[_\-\s]?name|firstname|fname|given[_\-\s]?name/.test(attrStr)) return 'firstName';
+  if (/\bfirst\b/.test(attrStr)) return 'firstName';
+  if (/last[_\-\s]?name|lastname|lname|sur[_\-\s]?name|family[_\-\s]?name/.test(attrStr)) return 'lastName';
+  if (/\blast\b/.test(attrStr)) return 'lastName';
+  if (/middle[_\-\s]?name|mname|\bmiddle\b/.test(attrStr)) return 'generic'; // too ambiguous
+
+  // full name — attr-value "name" without first/last context. `_`/`-`/space
+  // tolerant so full_name / your-name resolve, while username/filename/state
+  // are excluded.
+  if (/(^|[_\-\s])name([_\-\s]|$)|full[_\-\s]?name|fullname/.test(attrStr)
+      && !/state|filename|username|account|first|last/.test(attrStr)) return 'fullName';
+
+  // location fields (substring-tolerant for snake_case like zip_code)
+  if (/zip|postal|postcode/.test(attrStr)) return 'zip';
+  if (/\bcity\b|\btown\b|locality/.test(attrStr)) return 'city';
+  if (/\bstate\b|province|region/.test(attrStr)) return 'state';
+  if (/country/.test(attrStr)) return 'country';
+
+  // address — too broad; treat as generic to avoid wrong fills
+  if (/address/.test(attrStr)) return 'generic';
+
+  return 'generic';
+}
+
+/**
+ * Score a single DOM element against the target intent.
+ *
+ * Runs inside page.evaluate() — MUST be closure-free. It reads point values
+ * from `weights` and the confirm-field pattern from `negativeMarkerSrc`, both
+ * passed as parameters, so the serialized source has no free variables.
+ *
+ * A confirm / duplicate / secondary field always scores 0 (never a fill
+ * target) regardless of how strong its positive signals are.
+ *
+ * @param {Element} el
+ * @param {string} intent
+ * @param {{typeMatch:number, autocomplete:number, exactName:number, substring:number}} weights
+ * @param {string} negativeMarkerSrc  RegExp source for confirm/duplicate markers
+ * @returns {number}
+ */
+function scoreElement(el, intent, weights, negativeMarkerSrc) {
+  const tag = el.tagName.toLowerCase();
+  // Only score inputs, selects, textareas
+  if (!['input', 'select', 'textarea'].includes(tag)) return 0;
+
+  const type = (el.type || '').toLowerCase();
+  const name = (el.name || '').toLowerCase();
+  const id   = (el.id   || '').toLowerCase();
+  const placeholder = (el.placeholder || '').toLowerCase();
+  const autocomplete = (el.getAttribute('autocomplete') || '').toLowerCase();
+  const ariaLabel = (el.getAttribute('aria-label') || '').toLowerCase();
+
+  // Resolve associated <label> text (for= or wrapping label)
+  let labelText = '';
+  if (el.id) {
+    const lbl = document.querySelector('label[for="' + el.id + '"]');
+    if (lbl) labelText = lbl.textContent.trim().toLowerCase();
+  }
+  if (!labelText) {
+    let parent = el.parentElement;
+    while (parent && parent !== document.body) {
+      if (parent.tagName.toLowerCase() === 'label') {
+        labelText = parent.textContent.trim().toLowerCase();
+        break;
+      }
+      parent = parent.parentElement;
+    }
+  }
+
+  // ── Negative-signal guard ────────────────────────────────────────────────
+  // A confirm / duplicate / secondary field is never a fill target. Check every
+  // textual signal; any hit forces score 0 so the resolver abstains on it.
+  // INTENTIONAL: the guard is applied to FREE TEXT (placeholder/aria-label/
+  // labelText) as well as name/id — NOT restricted to name/id. A placeholder-only
+  // "Confirm email" field has no name/id marker, so dropping free text would let
+  // it become a fill target and re-open the confirm-field PII leak. Over-abstain
+  // is the intended safe side here: wrong-fill is worse than no-fill.
+  const negativeRe = new RegExp(negativeMarkerSrc, 'i');
+  if (negativeRe.test(name) || negativeRe.test(id) || negativeRe.test(placeholder)
+      || negativeRe.test(ariaLabel) || negativeRe.test(labelText)) {
+    return 0;
+  }
+
+  const W = weights;
+  let score = 0;
+
+  // ── intent-specific scoring ───────────────────────────────────────────────
+
+  if (intent === 'email') {
+    if (type === 'email') score += W.typeMatch;
+    if (autocomplete === 'email') score += W.autocomplete;
+    if (name === 'email') score += W.exactName;
+    else if (name.includes('email')) score += W.substring;
+    if (id === 'email' || id.includes('email')) score += W.substring;
+    if (placeholder.includes('email')) score += W.substring;
+    if (ariaLabel.includes('email')) score += W.substring;
+    if (labelText.includes('email')) score += W.substring;
+    return score;
+  }
+
+  if (intent === 'firstName') {
+    if (autocomplete === 'given-name') score += W.autocomplete;
+    if (name === 'firstname' || name === 'fname' || name === 'first_name' || name === 'first') score += W.exactName;
+    else if (name.includes('first') || name.includes('fname') || name.includes('given')) score += W.substring;
+    if (id.includes('first') || id.includes('fname') || id.includes('given')) score += W.substring;
+    if (placeholder.includes('first name') || placeholder.includes('firstname') || placeholder.includes('given')) score += W.substring;
+    if (ariaLabel.includes('first name') || ariaLabel.includes('firstname') || ariaLabel.includes('given')) score += W.substring;
+    if (labelText.includes('first name') || labelText.includes('given name')) score += W.substring;
+    return score;
+  }
+
+  if (intent === 'lastName') {
+    if (autocomplete === 'family-name') score += W.autocomplete;
+    if (name === 'lastname' || name === 'lname' || name === 'last_name' || name === 'last' || name === 'surname') score += W.exactName;
+    else if (name.includes('last') || name.includes('lname') || name.includes('surname') || name.includes('family')) score += W.substring;
+    if (id.includes('last') || id.includes('lname') || id.includes('surname') || id.includes('family')) score += W.substring;
+    if (placeholder.includes('last name') || placeholder.includes('lastname') || placeholder.includes('surname')) score += W.substring;
+    if (ariaLabel.includes('last name') || ariaLabel.includes('lastname') || ariaLabel.includes('surname')) score += W.substring;
+    if (labelText.includes('last name') || labelText.includes('family name') || labelText.includes('surname')) score += W.substring;
+    return score;
+  }
+
+  if (intent === 'fullName') {
+    if (autocomplete === 'name') score += W.autocomplete;
+    if (name === 'name' || name === 'full_name' || name === 'fullname') score += W.exactName;
+    else if (name.includes('name') && !name.includes('first') && !name.includes('last') && !name.includes('user') && !name.includes('file')) score += W.substring;
+    if (id.includes('name') && !id.includes('first') && !id.includes('last') && !id.includes('user')) score += W.substring;
+    if (placeholder.includes('full name') || placeholder.includes('your name') || placeholder.includes('name')) score += W.substring;
+    if (ariaLabel.includes('full name') || ariaLabel.includes('your name')) score += W.substring;
+    if (labelText.includes('name') && !labelText.includes('first') && !labelText.includes('last') && !labelText.includes('user')) score += W.substring;
+    return score;
+  }
+
+  if (intent === 'phone') {
+    if (type === 'tel') score += W.typeMatch;
+    if (autocomplete === 'tel') score += W.autocomplete;
+    if (name === 'phone' || name === 'tel' || name === 'mobile' || name === 'cell') score += W.exactName;
+    else if (name.includes('phone') || name.includes('mobile') || name.includes('cell') || name.includes('tel')) score += W.substring;
+    if (id.includes('phone') || id.includes('mobile') || id.includes('tel')) score += W.substring;
+    if (placeholder.includes('phone') || placeholder.includes('mobile') || placeholder.includes('tel')) score += W.substring;
+    if (ariaLabel.includes('phone') || ariaLabel.includes('mobile') || ariaLabel.includes('telephone')) score += W.substring;
+    if (labelText.includes('phone') || labelText.includes('mobile') || labelText.includes('telephone')) score += W.substring;
+    return score;
+  }
+
+  if (intent === 'zip') {
+    if (autocomplete === 'postal-code') score += W.autocomplete;
+    if (name === 'zip' || name === 'zipcode' || name === 'zip_code' || name === 'postal' || name === 'postcode') score += W.exactName;
+    else if (name.includes('zip') || name.includes('postal') || name.includes('postcode')) score += W.substring;
+    if (id.includes('zip') || id.includes('postal') || id.includes('postcode')) score += W.substring;
+    if (placeholder.includes('zip') || placeholder.includes('postal') || placeholder.includes('postcode')) score += W.substring;
+    if (ariaLabel.includes('zip') || ariaLabel.includes('postal')) score += W.substring;
+    if (labelText.includes('zip') || labelText.includes('postal') || labelText.includes('postcode')) score += W.substring;
+    return score;
+  }
+
+  if (intent === 'city') {
+    if (autocomplete === 'address-level2') score += W.autocomplete;
+    if (name === 'city' || name === 'town' || name === 'locality') score += W.exactName;
+    else if (name.includes('city') || name.includes('town') || name.includes('locality')) score += W.substring;
+    if (id.includes('city') || id.includes('town') || id.includes('locality')) score += W.substring;
+    if (placeholder.includes('city') || placeholder.includes('town')) score += W.substring;
+    if (ariaLabel.includes('city') || ariaLabel.includes('town')) score += W.substring;
+    if (labelText.includes('city') || labelText.includes('town')) score += W.substring;
+    return score;
+  }
+
+  if (intent === 'state') {
+    if (autocomplete === 'address-level1') score += W.autocomplete;
+    if (name === 'state' || name === 'province' || name === 'region') score += W.exactName;
+    else if (name.includes('state') || name.includes('province') || name.includes('region')) score += W.substring;
+    if (id.includes('state') || id.includes('province') || id.includes('region')) score += W.substring;
+    if (placeholder.includes('state') || placeholder.includes('province')) score += W.substring;
+    if (ariaLabel.includes('state') || ariaLabel.includes('province')) score += W.substring;
+    if (labelText.includes('state') || labelText.includes('province') || labelText.includes('region')) score += W.substring;
+    return score;
+  }
+
+  if (intent === 'country') {
+    if (autocomplete === 'country' || autocomplete === 'country-name') score += W.autocomplete;
+    if (name === 'country' || name === 'country_code') score += W.exactName;
+    else if (name.includes('country')) score += W.substring;
+    if (id.includes('country')) score += W.substring;
+    if (placeholder.includes('country')) score += W.substring;
+    if (ariaLabel.includes('country')) score += W.substring;
+    if (labelText.includes('country')) score += W.substring;
+    return score;
+  }
+
+  return 0; // intent === 'generic' → abstain
+}
+
+/**
+ * Marker attribute used to bind the scored winner to the element we fill.
+ * Set inside the same page.evaluate that scored, then located + removed.
+ */
+const RESOLVE_MARKER = 'data-aidr-resolve';
+
+/**
+ * Resolve a form field by semantic signals when all CSS selectors missed.
+ *
+ * Scans visible input/select/textarea elements, scores each against the
+ * derived intent inside a SINGLE page.evaluate, applies the threshold + tie
+ * abstain, and — if a unique winner clears the bar — tags that exact element
+ * with a data-* marker before returning. The winner is then located by the
+ * marker, never by index, so a DOM mutation between calls cannot redirect the
+ * fill to a different element. The caller (forms.js) clears the marker after
+ * the fill via clearResolveMarker().
+ *
+ * Returns null when:
+ *   - intent is 'generic' (too risky to guess)
+ *   - no candidate scores above MATCH_THRESHOLD (emits a console.warn so a
+ *     production miss is debuggable)
+ *   - two candidates tie for top score (ambiguous)
+ *   - the only viable candidates are confirm/duplicate fields (scored 0)
+ *
+ * @param {import('playwright').Page} page
+ * @param {string} selector  The CSS selector that already missed.
+ * @param {string} value     The value that was going to be filled.
+ * @returns {Promise<import('playwright').Locator|null>}
+ */
+async function resolveField(page, selector, value) {
+  const intent = deriveIntent(selector, value);
+  if (intent === 'generic') {
+    warnNoMatch(intent, selector);
+    return null;
+  }
+
+  // Score, threshold, tie-break, AND tag the winner all inside ONE evaluate so
+  // the selection is snapshot-consistent (no check-to-use gap on the DOM).
+  const scoreFnSrc = scoreElement.toString();
+  const CANDIDATE_SELECTOR =
+    'input:not([type="hidden"]):not([type="submit"]):not([type="button"]):not([type="reset"]):not([type="image"]), select, textarea';
+
+  const outcome = await page.evaluate(
+    ({ fnSrc, intent: targetIntent, threshold, weights, negativeMarkerSrc, candidateSelector, markerAttr }) => {
+      // Reconstruct scoreElement inside the browser context (closure-free).
+      // eslint-disable-next-line no-new-func
+      const scoreFn = new Function('return (' + fnSrc + ')')();
+      const candidates = Array.from(document.querySelectorAll(candidateSelector));
+
+      // Clear any stale marker from a previous (aborted) run.
+      candidates.forEach(el => el.removeAttribute(markerAttr));
+
+      const scored = candidates.map(el => {
+        const rect = el.getBoundingClientRect();
+        const visible = rect.width > 0 && rect.height > 0 && !el.hidden && el.type !== 'hidden';
+        const score = visible ? scoreFn(el, targetIntent, weights, negativeMarkerSrc) : 0;
+        return { el, score };
+      });
+
+      const above = scored.filter(s => s.score >= threshold);
+      if (above.length === 0) return { found: false };
+      above.sort((a, b) => b.score - a.score);
+      // Tie on the top score → ambiguous → abstain.
+      if (above.length >= 2 && above[1].score === above[0].score) return { found: false };
+
+      // Tag the unique winner so we fill THIS exact element, not nth(index).
+      above[0].el.setAttribute(markerAttr, '1');
+      return { found: true, score: above[0].score };
+    },
+    {
+      fnSrc: scoreFnSrc,
+      intent,
+      threshold: MATCH_THRESHOLD,
+      weights: SIGNAL_WEIGHTS,
+      negativeMarkerSrc: NEGATIVE_MARKER_SRC,
+      candidateSelector: CANDIDATE_SELECTOR,
+      markerAttr: RESOLVE_MARKER,
+    }
+  );
+
+  if (!outcome || !outcome.found) {
+    warnNoMatch(intent, selector);
+    return null;
+  }
+
+  // Locate by the marker attribute set on the SAME snapshot we scored.
+  return page.locator('[' + RESOLVE_MARKER + '="1"]');
+}
+
+/**
+ * Remove the resolve marker the resolver set on the winning element. Best-effort
+ * — a failure here is non-fatal (the marker is inert) but is swallowed so a
+ * detached node after fill does not throw.
+ *
+ * @param {import('playwright').Page} page
+ * @returns {Promise<void>}
+ */
+async function clearResolveMarker(page) {
+  await page
+    .evaluate((markerAttr) => {
+      document.querySelectorAll('[' + markerAttr + ']').forEach(el => el.removeAttribute(markerAttr));
+    }, RESOLVE_MARKER)
+    .catch(() => {});
+}
+
+/**
+ * Emit one observability line when the resolver abstains after every CSS
+ * selector already missed, so production misses are debuggable. The pre-existing
+ * catch(_) {} in forms.js stays untouched; this is the new path's own signal.
+ *
+ * @param {string} intent
+ * @param {string} selector
+ */
+function warnNoMatch(intent, selector) {
+  // eslint-disable-next-line no-console
+  console.warn('field-resolver: no match for intent=' + intent + ' selector=' + selector);
+}
+
+module.exports = {
+  resolveField,
+  deriveIntent,
+  clearResolveMarker,
+  MATCH_THRESHOLD,
+  SIGNAL_WEIGHTS,
+  RESOLVE_MARKER,
+};

--- a/lib/forms.js
+++ b/lib/forms.js
@@ -10,6 +10,7 @@
  */
 
 const { jitterSleep } = require('./timing');
+const { resolveField, clearResolveMarker } = require('./field-resolver');
 
 /**
  * Augment a formFields map for non-US users so that province/postal/postcode
@@ -131,12 +132,48 @@ async function fillForm(page, formFields, person, submissionEmail) {
       } catch(_) {}
     }
     if (!filled) {
+      // Primary fallback: getByLabel — only fires when the selector contains a
+      // *="..." substring match AND the extracted keyword is not ambiguous.
       const kw = extractKeyword(selector);
       if (kw && !isAmbiguousKeyword(kw)) {
         // Escape regex metacharacters before constructing the RegExp so that
         // keywords like "na(me" do not cause a SyntaxError.
         const escaped = kw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-        await page.getByLabel(new RegExp(escaped, 'i')).first().fill(value).catch(() => {});
+        const labelLocator = page.getByLabel(new RegExp(escaped, 'i'));
+        // Only flag the field as filled when getByLabel actually matched an
+        // element. A silent miss (no associated <label>) must NOT short-circuit
+        // the semantic resolver below — otherwise the renamed-attr + no-label
+        // failure mode, the exact case the resolver targets, is never reached.
+        const matched = await labelLocator.count().catch(() => 0);
+        if (matched > 0) {
+          await labelLocator.first().fill(value).catch(() => {});
+          filled = true; // genuine hit — prevent double-fill via semantic fallback
+        }
+      }
+    }
+    if (!filled) {
+      // Secondary fallback: semantic field resolver. Fires when the primary
+      // fallback was skipped (selector has no *="..." pattern — i.e. exact
+      // selectors like input[name="email"] — or the keyword was ambiguous).
+      // resolveField() scores visible elements by multi-signal heuristic and
+      // returns the best match above a conservative threshold, or null.
+      const resolved = await resolveField(page, selector, value).catch(() => null);
+      if (resolved) {
+        try {
+          const tag  = await resolved.evaluate(n => n.tagName.toLowerCase()).catch(() => '');
+          const type = await resolved.evaluate(n => n.type || '').catch(() => '');
+          if (tag === 'select') {
+            await resolved.selectOption({ label: value }).catch(() => resolved.selectOption(value).catch(() => {}));
+          } else if (type === 'checkbox' || type === 'radio') {
+            await resolved.check().catch(() => {});
+          } else {
+            await resolved.fill(value).catch(() => {});
+          }
+        } finally {
+          // Clear the snapshot marker the resolver set on the winning element,
+          // so the next field's resolve pass starts from a clean DOM.
+          await clearResolveMarker(page);
+        }
       }
     }
   }

--- a/test/field-resolver.browser.test.js
+++ b/test/field-resolver.browser.test.js
@@ -1,0 +1,266 @@
+/**
+ * test/field-resolver.browser.test.js
+ *
+ * Real-browser (headless Chromium) integration tests for lib/field-resolver.js
+ * and the secondary-fallback path in lib/forms.js.
+ *
+ * Runs ONLY when the environment variable AIDR_BROWSER_TESTS=1 is set, so the
+ * default `npm test` fast suite (browser-free) is unaffected. To run:
+ *
+ *   AIDR_BROWSER_TESTS=1 node --test test/field-resolver.browser.test.js
+ *
+ * These tests use real Playwright pages (`page.setContent(fixtureHTML)`) and
+ * drive the REAL `fillForm` / `resolveField` code path end-to-end. No mocks —
+ * the scorer is serialised through `page.evaluate` / `new Function` in a real
+ * Chromium process, the `data-aidr-resolve` marker binding is genuine, and
+ * `page.locator(...).inputValue()` reads actual DOM state.
+ *
+ * Scenario catalogue:
+ *   1. Recovery — renamed email attr (email→email_address), no label. Resolver
+ *      finds via type=email + autocomplete + placeholder.
+ *   2. Recovery — renamed firstName attr (first_name→given_name), no label.
+ *      Resolver finds via autocomplete=given-name + name.includes('given').
+ *   3. Confirm-guard — email + confirm_email present; resolver must fill the
+ *      PRIMARY email field and leave confirm_email EMPTY.
+ *   4. Asymmetric abstain (CASE A) — primary email has opaque attrs only
+ *      (name="usr_em", no type/autocomplete/placeholder), readable confirm
+ *      field present; resolver MUST abstain (both fields stay empty).
+ *   5. Happy path — exact selector hits; resolver NOT invoked (fill succeeds
+ *      via the primary CSS path, not the semantic fallback).
+ *   6. TOCTOU marker — data-aidr-resolve attribute is set during evaluate and
+ *      cleared after fill; verify start→set→cleared lifecycle.
+ */
+
+'use strict';
+
+const { describe, test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+
+const ENABLED = Boolean(process.env.AIDR_BROWSER_TESTS);
+
+// Wrap everything in a describe so that when AIDR_BROWSER_TESTS is unset the
+// whole suite registers as a single skipped block — no hard process.exit, no
+// worker-exit warning, no attempt to load playwright or a browser binary.
+describe('field-resolver browser integration', { skip: !ENABLED }, () => {
+  // Deferred requires: loaded only when the suite actually runs (ENABLED=true).
+  // This keeps CI from failing with "Chromium not found" when the flag is unset.
+  let chromium;
+  let fillForm;
+  let resolveField;
+  let clearResolveMarker;
+
+  let browser;
+  let chromiumVersion;
+
+  before(async () => {
+    ({ chromium } = require('playwright'));
+    ({ fillForm } = require('../lib/forms'));
+    ({ resolveField, clearResolveMarker } = require('../lib/field-resolver'));
+
+    browser = await chromium.launch({ headless: true });
+    // Capture Chromium version for reporting
+    const pg = await browser.newPage();
+    chromiumVersion = await pg.evaluate(() => navigator.userAgent);
+    await pg.close();
+    console.log('Browser:', chromiumVersion);
+  });
+
+  after(async () => {
+    await browser.close();
+  });
+
+  // ─── helpers ────────────────────────────────────────────────────────────────
+
+  async function makePage(html) {
+    const page = await browser.newPage();
+    await page.setContent(html, { waitUntil: 'domcontentloaded' });
+    return page;
+  }
+
+  async function readValue(page, selector) {
+    return page.locator(selector).inputValue();
+  }
+
+  // ─── Scenario 1: email field renamed email→email_address (no label) ─────────
+
+  test('S1: recovery — renamed email attr (email→email_address)', async () => {
+    // Broker DOM change: renamed name="email" → name="email_address".
+    // No <label>. Resolver should find it via: type=email(4) + autocomplete=email(3)
+    // + placeholder contains "email"(2) = 9 ≥ MATCH_THRESHOLD(5).
+    const html = `
+      <form>
+        <input name="email_address" type="email" autocomplete="email"
+               placeholder="Email" id="ea">
+      </form>`;
+
+    // formFields still references the OLD selector (what the broker config has)
+    const formFields = { 'input[name="email"]': 'test@example.com' };
+    const page = await makePage(html);
+    try {
+      await fillForm(page, formFields, null, null);
+      const got = await readValue(page, 'input[name="email_address"]');
+      assert.strictEqual(got, 'test@example.com',
+        `S1 FAIL: email_address field value="${got}", expected "test@example.com"`);
+      console.log('S1 PASS: email_address =', got);
+    } finally {
+      await page.close();
+    }
+  });
+
+  // ─── Scenario 1b: firstName field renamed first_name→given_name ─────────────
+
+  test('S1b: recovery — renamed firstName attr (first_name→given_name)', async () => {
+    // Broker renamed first_name→given_name. No label.
+    // Resolver: autocomplete=given-name(3) + name.includes('given')(2) = 5 ≥ threshold.
+    const html = `
+      <form>
+        <input name="given_name" type="text" autocomplete="given-name"
+               placeholder="Given name">
+      </form>`;
+
+    const formFields = { 'input[name="first_name"]': 'Alice' };
+    const page = await makePage(html);
+    try {
+      await fillForm(page, formFields, null, null);
+      const got = await readValue(page, 'input[name="given_name"]');
+      assert.strictEqual(got, 'Alice',
+        `S1b FAIL: given_name field value="${got}", expected "Alice"`);
+      console.log('S1b PASS: given_name =', got);
+    } finally {
+      await page.close();
+    }
+  });
+
+  // ─── Scenario 2: confirm-guard ───────────────────────────────────────────────
+
+  test('S2: confirm-guard — email lands in primary, confirm_email stays empty', async () => {
+    // Two fields: a real email field (primary selector MISSED so resolver fires)
+    // and a confirm_email field. The confirm field must score 0 (negative guard).
+    // Result: primary email filled; confirm_email EMPTY.
+    const html = `
+      <form>
+        <input name="user_email_addr" type="email" autocomplete="email"
+               placeholder="Your email" id="em">
+        <input name="confirm_email" type="email" placeholder="Confirm email" id="cem">
+      </form>`;
+
+    // selector uses old broker attr — misses both fields intentionally
+    const formFields = { 'input[name="email"]': 'user@example.com' };
+    const page = await makePage(html);
+    try {
+      await fillForm(page, formFields, null, null);
+      const primary = await readValue(page, 'input[name="user_email_addr"]');
+      const confirm = await readValue(page, 'input[name="confirm_email"]');
+      assert.strictEqual(primary, 'user@example.com',
+        `S2 FAIL: primary email="${primary}", expected "user@example.com"`);
+      assert.strictEqual(confirm, '',
+        `S2 FAIL: confirm_email="${confirm}", expected "" (empty — confirm guard)`);
+      console.log('S2 PASS: primary=', primary, '| confirm=', confirm, '(empty)');
+    } finally {
+      await page.close();
+    }
+  });
+
+  // ─── Scenario 3: asymmetric abstain (CASE A from review) ────────────────────
+
+  test('S3: asymmetric abstain — opaque primary, readable confirm → resolver abstains', async () => {
+    // Primary field: name="usr_em", no type=email, no autocomplete, no placeholder.
+    // Confirm field: name="confirm_email", type=email, placeholder="Confirm email".
+    //
+    // The resolver derives intent=email from the missed selector's value
+    // (test@example.com looks like email). Primary scores 0 (no signals).
+    // Confirm scores non-zero on type+placeholder... BUT the negative guard fires
+    // first and forces it to 0. So above=[] → abstain. Both fields stay empty.
+    const html = `
+      <form>
+        <input name="usr_em" type="text" id="ue">
+        <input name="confirm_email" type="email" placeholder="Confirm email" id="ce">
+      </form>`;
+
+    const formFields = { 'input[name="email"]': 'secret@example.com' };
+    const page = await makePage(html);
+    try {
+      await fillForm(page, formFields, null, null);
+      const primary = await readValue(page, 'input[name="usr_em"]');
+      const confirm = await readValue(page, 'input[name="confirm_email"]');
+      assert.strictEqual(primary, '',
+        `S3 FAIL: usr_em="${primary}", expected "" (abstain)`);
+      assert.strictEqual(confirm, '',
+        `S3 FAIL: confirm_email="${confirm}", expected "" (abstain — CASE A fail-safe)`);
+      console.log('S3 PASS: usr_em=', JSON.stringify(primary), '| confirm_email=', JSON.stringify(confirm));
+    } finally {
+      await page.close();
+    }
+  });
+
+  // ─── Scenario 4: happy path — exact selector hits, resolver not invoked ──────
+
+  test('S4: happy path — exact selector fills without resolver', async () => {
+    // The exact CSS selector hits; fillForm() fills it directly.
+    // To verify the resolver was NOT invoked we check: the data-aidr-resolve
+    // marker is absent after the fill (the resolver sets+clears it; if it was
+    // never set, it's absent). Also verify the field value.
+    const html = `
+      <form>
+        <input name="email" type="email" id="em">
+      </form>`;
+
+    const formFields = { 'input[name="email"]': 'happy@example.com' };
+    const page = await makePage(html);
+    try {
+      await fillForm(page, formFields, null, null);
+      const got = await readValue(page, 'input[name="email"]');
+      assert.strictEqual(got, 'happy@example.com',
+        `S4 FAIL: email="${got}", expected "happy@example.com"`);
+      // Confirm resolver marker was never set (primary path, no fallback)
+      const markerCount = await page.locator('[data-aidr-resolve]').count();
+      assert.strictEqual(markerCount, 0,
+        `S4 FAIL: data-aidr-resolve marker found (resolver was invoked when it shouldn't be)`);
+      console.log('S4 PASS: email=', got, '| resolver marker absent:', markerCount === 0);
+    } finally {
+      await page.close();
+    }
+  });
+
+  // ─── Scenario 5: TOCTOU marker lifecycle ────────────────────────────────────
+
+  test('S5: TOCTOU marker — data-aidr-resolve is set then cleared during fill', async () => {
+    // Drive resolveField() directly (not via fillForm) so we can capture the
+    // marker state at three points: before resolve, after resolve (before clear),
+    // and after clearResolveMarker.
+    const html = `
+      <form>
+        <input name="email_renamed" type="email" autocomplete="email"
+               placeholder="Email address">
+      </form>`;
+
+    const page = await makePage(html);
+    try {
+      // Before: no marker
+      const before = await page.locator('[data-aidr-resolve]').count();
+      assert.strictEqual(before, 0, 'S5 FAIL: marker present before resolve');
+
+      // After resolveField: marker set on the winner
+      const locator = await resolveField(page, 'input[name="email"]', 'mark@example.com');
+      assert.ok(locator !== null, 'S5 FAIL: resolveField returned null (scorer failed)');
+      const afterResolve = await page.locator('[data-aidr-resolve="1"]').count();
+      assert.strictEqual(afterResolve, 1, `S5 FAIL: marker count after resolve=${afterResolve}, expected 1`);
+
+      // Actually fill so the locator is consumed
+      await locator.fill('mark@example.com');
+      const filled = await readValue(page, 'input[name="email_renamed"]');
+      assert.strictEqual(filled, 'mark@example.com',
+        `S5 FAIL: fill value="${filled}", expected "mark@example.com"`);
+
+      // After clearResolveMarker: marker gone
+      await clearResolveMarker(page);
+      const afterClear = await page.locator('[data-aidr-resolve]').count();
+      assert.strictEqual(afterClear, 0,
+        `S5 FAIL: marker still present after clearResolveMarker, count=${afterClear}`);
+
+      console.log('S5 PASS: marker lifecycle before=0, during=1, after=0; filled=', filled);
+    } finally {
+      await page.close();
+    }
+  });
+}); // end describe 'field-resolver browser integration'

--- a/test/field-resolver.test.js
+++ b/test/field-resolver.test.js
@@ -1,0 +1,943 @@
+/**
+ * test/field-resolver.test.js
+ *
+ * Tests for lib/field-resolver.js (resolveField, deriveIntent) and the
+ * updated fillForm() secondary-fallback path in lib/forms.js.
+ *
+ * No real Playwright browser needed: we stub page.evaluate and page.locator
+ * the same way the rest of the test suite does (see forms-relay.test.js,
+ * forms-bugs.test.js for the established mock pattern).
+ *
+ * Coverage targets:
+ *   1. deriveIntent() — maps selector+value combos to the right intent.
+ *   2. resolveField() — correct candidate wins above MATCH_THRESHOLD.
+ *   3. resolveField() — abstains when score is below threshold.
+ *   4. resolveField() — abstains on tie (ambiguous candidates).
+ *   5. resolveField() — returns null for generic intent.
+ *   6. fillForm() secondary fallback — fires for exact selectors that miss
+ *      (input[name="email"]) which the primary getByLabel path never covers.
+ *   7. fillForm() secondary fallback — fires for ambiguous-keyword selectors
+ *      (input[name*="name"]) that the primary path kill-switches.
+ *   8. fillForm() happy path — exact selector hit is unchanged (no resolver).
+ *   9. fillForm() no double-fill — primary fallback success blocks resolver.
+ *  10. Fields with no <label for>, only placeholder — resolver recovers.
+ *  11. Fields with only aria-label — resolver recovers.
+ *  12. Renamed name attribute (broker DOM change) — resolver still matches.
+ */
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { deriveIntent, resolveField, MATCH_THRESHOLD, SIGNAL_WEIGHTS } = require('../lib/field-resolver');
+const { fillForm } = require('../lib/forms');
+
+// ─── Helper: build a mock element descriptor (used in page.evaluate stub) ────
+
+function makeEl(overrides = {}) {
+  return {
+    tagName: 'INPUT',
+    type: 'text',
+    name: '',
+    id: '',
+    placeholder: '',
+    autocomplete: '',
+    'aria-label': '',
+    hidden: false,
+    parentElement: null,
+    _attrs: {},
+    getBoundingClientRect: () => ({ width: 100, height: 30 }),
+    getAttribute(attr) {
+      if (Object.prototype.hasOwnProperty.call(this._attrs, attr)) return this._attrs[attr];
+      if (attr === 'autocomplete') return this.autocomplete || '';
+      if (attr === 'aria-label') return this['aria-label'] || '';
+      return null;
+    },
+    setAttribute(attr, val) { this._attrs[attr] = String(val); },
+    removeAttribute(attr) { delete this._attrs[attr]; },
+    hasAttribute(attr) { return Object.prototype.hasOwnProperty.call(this._attrs, attr); },
+    ...overrides,
+  };
+}
+
+// ─── Build stub page for resolveField ────────────────────────────────────────
+
+/**
+ * Build a stub page that faithfully mirrors real Playwright page.evaluate /
+ * page.locator semantics for the resolver's snapshot-consistent selection.
+ *
+ *   - evaluate(fn, arg): runs the REAL production callback `fn(arg)` against a
+ *     mock `document` whose querySelectorAll returns these candidate objects.
+ *     The candidates carry setAttribute/removeAttribute, so the production code
+ *     that scores → threshold → tie-break → tags the winner with a data-* marker
+ *     runs UNMODIFIED here (no second source of truth). This is what lets the
+ *     selection logic and the marker semantics be exercised for real.
+ *   - locator(sel): resolves to the candidate(s) matching `sel`. We model the
+ *     marker attribute selector `[data-aidr-resolve="1"]` (used by resolveField)
+ *     so .fill() hits the EXACT element that was tagged, not an index.
+ *
+ * `mutate` (optional) is a callback invoked ONCE, AFTER the scoring evaluate
+ * but BEFORE the locator resolves — it lets a test model a DOM mutation between
+ * the score round-trip and the use round-trip (the TOCTOU window). A faithful
+ * mock can only approximate the browser here: the production fix tags the
+ * winner DURING the scoring evaluate, so a post-score mutation that does not
+ * touch the marker leaves the fill bound to the originally-scored element. A
+ * mock that re-selected by numeric index (the OLD design) would instead bind to
+ * whatever now sits at that index — that divergence is exactly the race.
+ */
+function makeResolvePage(candidates, opts = {}) {
+  const RESOLVE_MARKER = 'data-aidr-resolve';
+  let scored = false;
+
+  function matches(el, sel) {
+    if (sel === '[' + RESOLVE_MARKER + '="1"]') return el.getAttribute(RESOLVE_MARKER) === '1';
+    if (sel === '[' + RESOLVE_MARKER + ']') return el.hasAttribute(RESOLVE_MARKER);
+    // Treat any other selector as "all input/select/textarea" candidates.
+    return true;
+  }
+
+  const page = {
+    async evaluate(fn, arg) {
+      // Run the REAL production callback against a mock document.
+      const savedDoc = typeof global.document !== 'undefined' ? global.document : undefined;
+      global.document = {
+        querySelector: () => null,
+        querySelectorAll: (sel) => candidates.filter(el => matches(el, sel)),
+        body: {},
+      };
+      try {
+        const result = await fn(arg);
+        if (!scored && typeof opts.mutate === 'function') {
+          // Model a DOM mutation occurring after the score+tag round-trip.
+          scored = true;
+          opts.mutate(candidates);
+        }
+        return result;
+      } finally {
+        if (savedDoc !== undefined) global.document = savedDoc;
+        else delete global.document;
+      }
+    },
+    locator(sel) {
+      const resolve = () => candidates.find(el => matches(el, sel)) || null;
+      const makeHandle = () => ({
+        get _resolvedEl() { return resolve(); },
+        async evaluate(fn) {
+          const el = resolve();
+          const fakeNode = { tagName: (el && el.tagName) || 'INPUT', type: (el && el.type) || 'text' };
+          return fn(fakeNode);
+        },
+        async fill(v) { const el = resolve(); if (el) el._filledWith = v; },
+        async selectOption() {},
+        async check() { const el = resolve(); if (el) el._checked = true; },
+      });
+      return Object.assign(makeHandle(), {
+        first: makeHandle,
+        nth: makeHandle,
+      });
+    },
+  };
+  return page;
+}
+
+// ─── 1. deriveIntent ──────────────────────────────────────────────────────────
+
+test('deriveIntent: input[name="email"] → email', () => {
+  assert.equal(deriveIntent('input[name="email"]', 'user@example.com'), 'email');
+});
+
+test('deriveIntent: input[type="email"] → email', () => {
+  assert.equal(deriveIntent('input[type="email"]', ''), 'email');
+});
+
+test('deriveIntent: value looks like email address → email', () => {
+  assert.equal(deriveIntent('input[name="contact"]', 'user@example.com'), 'email');
+});
+
+test('deriveIntent: input[name="firstName"] → firstName', () => {
+  assert.equal(deriveIntent('input[name="firstName"]', 'Jane'), 'firstName');
+});
+
+test('deriveIntent: input[name="lastname"] → lastName', () => {
+  assert.equal(deriveIntent('input[name="lastname"]', 'Doe'), 'lastName');
+});
+
+test('deriveIntent: input[name="name"] → fullName', () => {
+  assert.equal(deriveIntent('input[name="name"]', 'Jane Doe'), 'fullName');
+});
+
+test('deriveIntent: input[name*="name" i] → fullName', () => {
+  assert.equal(deriveIntent('input[name*="name" i]', 'Jane Doe'), 'fullName');
+});
+
+test('deriveIntent: input[name*="first" i] → firstName', () => {
+  assert.equal(deriveIntent('input[name*="first" i]', 'Jane'), 'firstName');
+});
+
+test('deriveIntent: input[name*="last" i] → lastName', () => {
+  assert.equal(deriveIntent('input[name*="last" i]', 'Doe'), 'lastName');
+});
+
+test('deriveIntent: input[name="phone"] → phone', () => {
+  assert.equal(deriveIntent('input[name="phone"]', '5551234567'), 'phone');
+});
+
+test('deriveIntent: input[name="zip"] → zip', () => {
+  assert.equal(deriveIntent('input[name="zip"]', '90210'), 'zip');
+});
+
+test('deriveIntent: input[name="city"] → city', () => {
+  assert.equal(deriveIntent('input[name="city"]', 'Austin'), 'city');
+});
+
+test('deriveIntent: address selector → generic (too ambiguous to fill)', () => {
+  assert.equal(deriveIntent('input[name="address"]', '123 Main St'), 'generic');
+});
+
+test('deriveIntent: unknown selector with plain text value → generic', () => {
+  assert.equal(deriveIntent('input[name="something_random"]', 'hello'), 'generic');
+});
+
+// ─── 2. resolveField: correct candidate wins ─────────────────────────────────
+
+test('resolveField: picks email input by type=email (score >> threshold)', async () => {
+  const candidates = [
+    makeEl({ name: 'submit_btn', type: 'submit', tagName: 'INPUT' }),
+    makeEl({ name: 'email', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'email address' }),
+    makeEl({ name: 'city', type: 'text', tagName: 'INPUT' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="email"]', 'user@example.com');
+
+  assert.ok(result !== null, 'should resolve a candidate for email intent');
+  assert.equal(result._resolvedEl, candidates[1], 'should pick the email input (index 1)');
+});
+
+test('resolveField: picks firstName by autocomplete=given-name', async () => {
+  const candidates = [
+    makeEl({ name: 'first_name_field_v2', type: 'text', tagName: 'INPUT', autocomplete: 'given-name', placeholder: 'First name' }),
+    makeEl({ name: 'email', type: 'email', tagName: 'INPUT', autocomplete: 'email' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="firstName"]', 'Jane');
+
+  assert.ok(result !== null, 'should resolve firstName candidate');
+  assert.equal(result._resolvedEl, candidates[0], 'should pick the first-name input (index 0)');
+});
+
+test('resolveField: picks lastName by name attribute', async () => {
+  const candidates = [
+    makeEl({ name: 'first_name', type: 'text', tagName: 'INPUT', autocomplete: 'given-name' }),
+    makeEl({ name: 'last_name', type: 'text', tagName: 'INPUT', autocomplete: 'family-name', placeholder: 'Last name' }),
+    makeEl({ name: 'email', type: 'email', tagName: 'INPUT' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="lastName"]', 'Doe');
+
+  assert.ok(result !== null, 'should resolve lastName candidate');
+  assert.equal(result._resolvedEl, candidates[1], 'should pick the last-name input (index 1)');
+});
+
+// ─── 3. resolveField: below threshold — abstains ─────────────────────────────
+
+test('resolveField: returns null when no candidate scores above MATCH_THRESHOLD', async () => {
+  // Only weak signal: placeholder contains "mail" (not "email"), score = 2
+  const candidates = [
+    makeEl({ name: 'contact_info', type: 'text', tagName: 'INPUT', placeholder: 'mail' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="email"]', 'user@example.com');
+
+  assert.equal(result, null, 'should return null when score < MATCH_THRESHOLD');
+});
+
+// ─── 4. resolveField: tie — abstains ─────────────────────────────────────────
+
+test('resolveField: returns null when two candidates share the same top score', async () => {
+  // Both candidates are structurally identical — exact same score for email intent.
+  // Same name, type, autocomplete, placeholder ⇒ identical scoring → tie.
+  const candidates = [
+    makeEl({ name: 'email', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'email address' }),
+    makeEl({ name: 'email', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'email address' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="email"]', 'user@example.com');
+
+  assert.equal(result, null, 'should return null on tied scores (ambiguous)');
+});
+
+// ─── 5. resolveField: generic intent — abstains ───────────────────────────────
+
+test('resolveField: returns null for generic intent', async () => {
+  const candidates = [
+    makeEl({ name: 'address', type: 'text', tagName: 'INPUT' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  // address selector → generic intent
+  const result = await resolveField(page, 'input[name="address"]', '123 Main St');
+
+  assert.equal(result, null, 'generic intent should always abstain');
+});
+
+// ─── 6. fillForm: secondary fallback fires for exact selector miss ────────────
+//  The provable gap: input[name="email"] has no *="..." pattern → extractKeyword
+//  returns null → primary getByLabel path is skipped → previously no fallback.
+
+// Build a page mock for fillForm() integration: the CSS selector miss path
+// (.first().count()===0) routes to the resolver, whose score→tag→locate→fill
+// runs against the REAL production callback over `candidates`. getByLabel is a
+// no-op (primary fallback). A flag records whether the resolver's evaluate ran.
+function makeFillFormPage(candidates) {
+  const RESOLVE_MARKER = 'data-aidr-resolve';
+  const state = { resolverCalled: false };
+
+  // page.locator(sel): only marker selectors resolve; broker CSS selectors miss
+  // so the fallback (and then the resolver) is exercised.
+  function locatorMatches(el, sel) {
+    if (sel === '[' + RESOLVE_MARKER + '="1"]') return el.getAttribute(RESOLVE_MARKER) === '1';
+    if (sel === '[' + RESOLVE_MARKER + ']') return el.hasAttribute(RESOLVE_MARKER);
+    return false; // CSS selectors always miss → exercise the fallback
+  }
+  // document.querySelectorAll(sel) inside evaluate: marker selectors resolve to
+  // the tagged element; the candidate selector resolves to all candidates.
+  function qsaMatches(el, sel) {
+    if (sel === '[' + RESOLVE_MARKER + '="1"]') return el.getAttribute(RESOLVE_MARKER) === '1';
+    if (sel === '[' + RESOLVE_MARKER + ']') return el.hasAttribute(RESOLVE_MARKER);
+    return true; // the input/select/textarea candidate selector matches all
+  }
+
+  const page = {
+    locator(sel) {
+      const resolve = () => candidates.find(el => locatorMatches(el, sel)) || null;
+      const handle = {
+        get _resolvedEl() { return resolve(); },
+        async count() { return resolve() ? 1 : 0; },
+        async isVisible() { return !!resolve(); },
+        async evaluate(fn) {
+          const el = resolve();
+          return fn({ tagName: (el && el.tagName) || 'INPUT', type: (el && el.type) || 'text' });
+        },
+        async fill(v) { const el = resolve(); if (el) el._filledWith = v; },
+        async selectOption() {},
+        async check() { const el = resolve(); if (el) el._checked = true; },
+      };
+      return Object.assign(handle, { first: () => handle, nth: () => handle });
+    },
+    getByLabel() {
+      return { first() { return { async fill() {} }; } };
+    },
+    async evaluate(fn, arg) {
+      // Distinguish the scoring evaluate (has fnSrc) from clearResolveMarker.
+      if (arg && typeof arg === 'object' && arg.fnSrc) state.resolverCalled = true;
+      const savedDoc = typeof global.document !== 'undefined' ? global.document : undefined;
+      global.document = {
+        querySelector: () => null,
+        querySelectorAll: (sel) => candidates.filter(el => qsaMatches(el, sel)),
+        body: {},
+      };
+      try {
+        return await fn(arg);
+      } finally {
+        if (savedDoc !== undefined) global.document = savedDoc;
+        else delete global.document;
+      }
+    },
+  };
+  return { page, state };
+}
+
+test('fillForm: secondary resolver fires when exact selector input[name="email"] misses', async () => {
+  const candidates = [
+    makeEl({ name: 'email', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'email address' }),
+  ];
+  const { page, state } = makeFillFormPage(candidates);
+
+  await fillForm(page, { 'input[name="email"]': 'user@example.com' });
+
+  assert.ok(state.resolverCalled, 'resolveField should have been invoked via page.evaluate');
+  assert.equal(candidates[0]._filledWith, 'user@example.com', 'resolver should fill the correct value into the marked element');
+  assert.ok(!candidates[0].hasAttribute('data-aidr-resolve'), 'marker should be cleared after fill');
+});
+
+// ─── 7. fillForm: secondary fallback fires for ambiguous-keyword selectors ────
+//  input[name*="name" i] has *="..." → extractKeyword = "name" → isAmbiguousKeyword
+//  → primary path kill-switched → previously silent failure.
+
+test('fillForm: secondary resolver fires when primary is kill-switched (ambiguous keyword "name")', async () => {
+  const candidates = [
+    makeEl({ name: 'name', type: 'text', tagName: 'INPUT', autocomplete: 'name', placeholder: 'Full name' }),
+  ];
+  const { page, state } = makeFillFormPage(candidates);
+
+  await fillForm(page, { 'input[name*="name" i]': 'Jane Doe' });
+
+  assert.ok(state.resolverCalled, 'resolver should have been called for ambiguous-keyword selector miss');
+  assert.equal(candidates[0]._filledWith, 'Jane Doe', 'resolver should fill the correct value into the marked element');
+});
+
+// ─── 8. fillForm: happy path — exact selector hit, resolver never invoked ────
+
+test('fillForm: resolver is NOT invoked when the exact selector hits on first try', async () => {
+  let resolverInvoked = false;
+  const fills = [];
+
+  const page = {
+    locator(sel) {
+      return {
+        first() {
+          return {
+            async count() { return 1; },        // HIT
+            async isVisible() { return true; },
+            async evaluate(fn) { return fn({ tagName: 'INPUT', type: 'text' }); },
+            async fill(v) { fills.push({ sel, v }); },
+            async selectOption() {},
+            async check() {},
+          };
+        },
+      };
+    },
+    getByLabel() {
+      return { first() { return { async fill() {} }; } };
+    },
+    async evaluate() {
+      resolverInvoked = true;
+      return [];
+    },
+  };
+
+  await fillForm(page, { 'input[name="email"]': 'user@example.com' });
+
+  assert.ok(!resolverInvoked, 'resolver must NOT fire when selector hits');
+  assert.equal(fills.length, 1, 'field should be filled directly');
+  assert.equal(fills[0].v, 'user@example.com');
+});
+
+// ─── 9. fillForm: no double-fill — primary fallback success blocks resolver ───
+
+test('fillForm: resolver is NOT invoked when primary getByLabel fallback succeeds', async () => {
+  let resolverInvoked = false;
+  let primaryFilled = false;
+
+  const page = {
+    locator() {
+      return {
+        first() {
+          return {
+            async count() { return 0; },   // miss — trigger fallback
+            async isVisible() { return false; },
+          };
+        },
+      };
+    },
+    getByLabel() {
+      return {
+        async count() { return 1; }, // getByLabel HIT — one matching element
+        first() {
+          return {
+            async fill() { primaryFilled = true; },
+          };
+        },
+      };
+    },
+    async evaluate() {
+      resolverInvoked = true;
+      return [];
+    },
+  };
+
+  // *="email" → extractKeyword = "email" → not ambiguous → primary fires
+  await fillForm(page, { 'input[name*="email" i]': 'user@example.com' });
+
+  assert.ok(primaryFilled, 'primary getByLabel should have been called');
+  assert.ok(!resolverInvoked, 'resolver must NOT fire after primary fallback');
+});
+
+// ─── 9b. fillForm: getByLabel SILENT MISS must NOT short-circuit the resolver ──
+//
+// The MAJOR gap this PR exists to close. When BOTH the CSS selector loop AND the
+// primary getByLabel fallback miss (broker renamed the attribute AND the input
+// has no associated <label> for getByLabel to hit), the resolver MUST still fire.
+//
+// Before the fix, fillForm() set `filled = true` UNCONDITIONALLY after calling
+// getByLabel().first().fill().catch(() => {}) — so a getByLabel that matched
+// nothing still flagged the field as filled and the semantic resolver was
+// SKIPPED, defeating the entire purpose of the PR for exactly the failure mode
+// it targets (renamed attr + no label).
+//
+// This mock models a REAL getByLabel miss: count()===0 and a .fill() whose
+// underlying promise rejects (mirrors Playwright's "element not found" → the
+// pre-existing .catch(() => {}) swallow). No candidate is filled by getByLabel.
+// A resolvable field exists (matchable by name/placeholder/aria), so the
+// resolver must fire and fill it.
+function makeLabelMissPage(candidates) {
+  const RESOLVE_MARKER = 'data-aidr-resolve';
+  const state = { resolverCalled: false, getByLabelAttempted: false };
+
+  function locatorMatches(el, sel) {
+    if (sel === '[' + RESOLVE_MARKER + '="1"]') return el.getAttribute(RESOLVE_MARKER) === '1';
+    if (sel === '[' + RESOLVE_MARKER + ']') return el.hasAttribute(RESOLVE_MARKER);
+    return false; // every broker CSS selector misses → exercise the fallback chain
+  }
+  function qsaMatches(el, sel) {
+    if (sel === '[' + RESOLVE_MARKER + '="1"]') return el.getAttribute(RESOLVE_MARKER) === '1';
+    if (sel === '[' + RESOLVE_MARKER + ']') return el.hasAttribute(RESOLVE_MARKER);
+    return true; // input/select/textarea candidate selector matches all
+  }
+
+  const page = {
+    locator(sel) {
+      const resolve = () => candidates.find(el => locatorMatches(el, sel)) || null;
+      const handle = {
+        get _resolvedEl() { return resolve(); },
+        async count() { return resolve() ? 1 : 0; },
+        async isVisible() { return !!resolve(); },
+        async evaluate(fn) {
+          const el = resolve();
+          return fn({ tagName: (el && el.tagName) || 'INPUT', type: (el && el.type) || 'text' });
+        },
+        async fill(v) { const el = resolve(); if (el) el._filledWith = v; },
+        async selectOption() {},
+        async check() { const el = resolve(); if (el) el._checked = true; },
+      };
+      return Object.assign(handle, { first: () => handle, nth: () => handle });
+    },
+    getByLabel() {
+      // A genuine getByLabel MISS: count()===0 (no element matches the label),
+      // mirroring Playwright Locator semantics. The production code reads count()
+      // first and must NOT flag the field filled. .fill() would reject here too
+      // (no element), but the count() gate means it is never reached.
+      state.getByLabelAttempted = true;
+      return {
+        async count() { return 0; }, // silent miss — zero matching elements
+        first() {
+          return { async fill() { throw new Error('locator.fill: no element matches the label'); } };
+        },
+      };
+    },
+    async evaluate(fn, arg) {
+      if (arg && typeof arg === 'object' && arg.fnSrc) state.resolverCalled = true;
+      const savedDoc = typeof global.document !== 'undefined' ? global.document : undefined;
+      global.document = {
+        querySelector: () => null,
+        querySelectorAll: (sel) => candidates.filter(el => qsaMatches(el, sel)),
+        body: {},
+      };
+      try {
+        return await fn(arg);
+      } finally {
+        if (savedDoc !== undefined) global.document = savedDoc;
+        else delete global.document;
+      }
+    },
+  };
+  return { page, state };
+}
+
+test('fillForm: resolver FIRES when CSS miss + getByLabel silently misses (renamed attr, no label)', async () => {
+  // Broker renamed name="email" → name="email_address" (CSS selector
+  // input[name*="email" i] still keyword-extracts "email", so the PRIMARY
+  // getByLabel path is entered), but the input has NO associated <label> so
+  // getByLabel matches nothing. A resolvable email field is present.
+  const candidates = [
+    makeEl({ name: 'email_address', id: 'email_address', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'email address' }),
+  ];
+  const { page, state } = makeLabelMissPage(candidates);
+
+  await fillForm(page, { 'input[name*="email" i]': 'user@example.com' });
+
+  assert.ok(state.getByLabelAttempted, 'primary getByLabel path should have been entered (non-ambiguous keyword)');
+  assert.ok(state.resolverCalled, 'resolver MUST fire after a SILENT getByLabel miss — not be short-circuited by filled=true');
+  assert.equal(candidates[0]._filledWith, 'user@example.com', 'resolver should fill the renamed email field that getByLabel could not reach');
+  assert.ok(!candidates[0].hasAttribute('data-aidr-resolve'), 'marker cleared after fill');
+});
+
+// Companion to 9 + 9b: getByLabel SUCCESS still short-circuits the resolver
+// (no double-fill). With the fix, filled=true is gated on getByLabel actually
+// matching ≥1 element — so a real hit must still block the resolver.
+test('fillForm: getByLabel SUCCESS short-circuits the resolver (no double-fill)', async () => {
+  let resolverInvoked = false;
+  let primaryFillCount = 0;
+
+  const page = {
+    locator() {
+      return { first() { return { async count() { return 0; }, async isVisible() { return false; } }; } };
+    },
+    getByLabel() {
+      return {
+        async count() { return 1; },                  // getByLabel HIT
+        first() { return { async fill() { primaryFillCount += 1; } }; },
+      };
+    },
+    async evaluate() { resolverInvoked = true; return { found: false }; },
+  };
+
+  // *="email" → non-ambiguous keyword → primary path entered, getByLabel matches.
+  await fillForm(page, { 'input[name*="email" i]': 'user@example.com' });
+
+  assert.equal(primaryFillCount, 1, 'getByLabel should fill exactly once');
+  assert.ok(!resolverInvoked, 'a real getByLabel hit must still short-circuit the resolver (no double-fill)');
+});
+
+// ─── 10. resolveField: placeholder-only field (no label, no name) ─────────────
+
+test('resolveField: recovers when field has only a placeholder for email intent', async () => {
+  const candidates = [
+    // No name, no id, no label, no autocomplete — just placeholder
+    makeEl({ name: '', id: '', type: 'email', tagName: 'INPUT', placeholder: 'your email address', autocomplete: '' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="emailAddress"]', 'user@example.com');
+
+  // type=email alone = 4 pts; placeholder contains "email" = 2 pts → total 6 ≥ 5
+  assert.ok(result !== null, 'should recover from placeholder-only email field');
+  assert.equal(result._resolvedEl, candidates[0]);
+});
+
+// ─── 11. resolveField: aria-label-only field ─────────────────────────────────
+
+test('resolveField: recovers when field has only an aria-label for email intent', async () => {
+  const candidates = [
+    makeEl({ name: '', id: '', type: 'text', tagName: 'INPUT', placeholder: '', autocomplete: '', 'aria-label': 'Email address' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="email_contact"]', 'user@example.com');
+
+  // type text = 0; aria-label includes "email" = 2 pts — below threshold alone
+  // We need the value to push over: value looks like email → intent=email
+  // BUT score from aria-label alone = 2 < 5. Correct result is null.
+  // The resolver is conservative — it should NOT match on a single weak signal.
+  // This tests that we DON'T over-reach.
+  assert.equal(result, null, 'single weak signal (aria-label=2) must not exceed threshold');
+});
+
+test('resolveField: recovers when field combines aria-label + autocomplete for email intent', async () => {
+  const candidates = [
+    // autocomplete=email (3) + aria-label includes email (2) = 5 ≥ threshold
+    makeEl({ name: '', id: '', type: 'text', tagName: 'INPUT', placeholder: '', autocomplete: 'email', 'aria-label': 'Email address' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="contact_field"]', 'user@example.com');
+
+  assert.ok(result !== null, 'aria-label + autocomplete should cross threshold');
+  assert.equal(result._resolvedEl, candidates[0]);
+});
+
+// ─── 12. resolveField: renamed name attribute (broker DOM change) ─────────────
+
+test('resolveField: matches firstName when broker renamed attr to given_name_v2', async () => {
+  const candidates = [
+    // Broker renamed: name="first" → name="given_name_v2"
+    // But autocomplete and placeholder still signal the intent
+    makeEl({ name: 'given_name_v2', type: 'text', tagName: 'INPUT', autocomplete: 'given-name', placeholder: 'Given name' }),
+    makeEl({ name: 'family_name_v2', type: 'text', tagName: 'INPUT', autocomplete: 'family-name', placeholder: 'Family name' }),
+    makeEl({ name: 'contact_email_v2', type: 'email', tagName: 'INPUT', autocomplete: 'email' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  // Original selector: input[name="firstName"] missed (broker renamed the attr)
+  const result = await resolveField(page, 'input[name="firstName"]', 'Jane');
+
+  assert.ok(result !== null, 'should match despite renamed name attribute');
+  assert.equal(result._resolvedEl, candidates[0], 'should pick given_name_v2 (index 0)');
+});
+
+test('resolveField: matches lastName when broker renamed attr to family_name_v2', async () => {
+  const candidates = [
+    makeEl({ name: 'given_name_v2', type: 'text', tagName: 'INPUT', autocomplete: 'given-name', placeholder: 'Given name' }),
+    makeEl({ name: 'family_name_v2', type: 'text', tagName: 'INPUT', autocomplete: 'family-name', placeholder: 'Family name' }),
+  ];
+
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="lastName"]', 'Doe');
+
+  assert.ok(result !== null, 'should match despite renamed name attribute');
+  assert.equal(result._resolvedEl, candidates[1], 'should pick family_name_v2 (index 1)');
+});
+
+// ─── 13. HIGH — confirm / duplicate / secondary field PII guard ──────────────
+//
+// The fail-safe invariant ("a wrong fill is worse than no fill") must hold on
+// every confirm/duplicate layout. A confirm field carries the SAME positive
+// signals (type=email, autocomplete=email) as the primary, so without a
+// negative-signal penalty it scores as high or higher and the resolver fills
+// the user's PII into the wrong box. The matrix below proves abstention.
+
+// CASE F — a SOLE visible confirm field (no primary present). The resolver must
+// abstain: there is nothing legitimate to fill, and filling the confirm box
+// leaves the masked email in the wrong field with the primary empty.
+test('confirm-guard CASE F: sole confirm_email → abstain (no primary present)', async () => {
+  const candidates = [
+    makeEl({ name: 'confirm_email', id: 'confirm_email', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'Confirm email' }),
+  ];
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="email"]', 'relay@mask.example');
+  assert.equal(result, null, 'sole confirm field must not be filled');
+});
+
+// CASE A — the dangerous asymmetric layout: primary email renamed unreadable
+// (name="usr_em", no type) while a fully-readable confirm field exists. The
+// confirm would win outright (no tie → the symmetric tie-break cannot save it).
+// With the negative guard the confirm scores 0 and the primary is unreadable,
+// so the resolver abstains — it never lands the email only in the confirm box.
+test('confirm-guard CASE A: primary unreadable + confirm readable → abstain (never fills confirm)', async () => {
+  const primary = makeEl({ name: 'usr_em', id: '', type: 'text', tagName: 'INPUT', autocomplete: '', placeholder: '' });
+  const confirm = makeEl({ name: 'confirm_email', id: 'confirm_email', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'Confirm email' });
+  const candidates = [primary, confirm];
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="email"]', 'relay@mask.example');
+  assert.equal(result, null, 'must abstain — filling the confirm field breaks email !== confirm submission');
+  assert.ok(!confirm.hasAttribute('data-aidr-resolve'), 'confirm field must never be tagged as the winner');
+});
+
+// CASE primary+confirm both readable — the resolver MUST pick the primary, never
+// the confirm. This proves the guard does not over-abstain on a legit layout.
+test('confirm-guard: primary readable + confirm readable → fills the PRIMARY only', async () => {
+  const primary = makeEl({ name: 'email', id: 'email', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'Email' });
+  const confirm = makeEl({ name: 'confirm_email', id: 'confirm_email', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'Confirm email' });
+  const candidates = [primary, confirm];
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="email_addr"]', 'relay@mask.example');
+  assert.ok(result !== null, 'a readable primary should resolve');
+  assert.equal(result._resolvedEl, primary, 'must pick the primary, not the confirm');
+});
+
+// RAW-PII variants — name/phone/zip confirm fields carry real PII, not a masked
+// relay address. Each sole-confirm layout must abstain.
+test('confirm-guard: sole confirm_first_name (RAW name PII) → abstain', async () => {
+  const candidates = [
+    makeEl({ name: 'confirm_first_name', id: 'confirm_first_name', type: 'text', tagName: 'INPUT', autocomplete: 'given-name', placeholder: 'Confirm first name' }),
+  ];
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="firstName"]', 'Jane');
+  assert.equal(result, null, 'raw name PII must not land in a confirm field');
+});
+
+test('confirm-guard: sole verify_phone (RAW phone PII) → abstain', async () => {
+  const candidates = [
+    makeEl({ name: 'verify_phone', id: 'verify_phone', type: 'tel', tagName: 'INPUT', autocomplete: 'tel', placeholder: 'Verify phone' }),
+  ];
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="phone"]', '5551234567');
+  assert.equal(result, null, 'raw phone PII must not land in a verify field');
+});
+
+test('confirm-guard: sole zip2 (bare trailing-2 duplicate) → abstain', async () => {
+  const candidates = [
+    makeEl({ name: 'zip2', id: 'zip2', type: 'text', tagName: 'INPUT', autocomplete: 'postal-code', placeholder: 'Zip' }),
+  ];
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="zip"]', '90210');
+  assert.equal(result, null, 'bare trailing-2 duplicate must abstain');
+});
+
+test('confirm-guard: secondary_email / re-enter / repeat markers all abstain', async () => {
+  for (const marker of ['secondary_email', 'reenter_email', 're-enter_email', 'email_repeat', 'email_again', 'alt_email', 'email_2', 'email-2']) {
+    const candidates = [
+      makeEl({ name: marker, id: marker, type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'Email' }),
+    ];
+    const page = makeResolvePage(candidates);
+    const result = await resolveField(page, 'input[name="email"]', 'relay@mask.example');
+    assert.equal(result, null, `marker "${marker}" must abstain`);
+  }
+});
+
+// MINOR — JSDoc advertises dup(licate); the guard must abstain on BOTH the
+// short token "dup" AND the full word "duplicate". Before strengthening the
+// alternation to dup(?:licate)?, "duplicate_email" did NOT match and would be
+// a fill target — a doc/regex mismatch on the SAFE side of the negative guard.
+test('confirm-guard: dup AND duplicate markers both abstain (doc/regex parity)', async () => {
+  for (const marker of ['dup_email', 'duplicate_email', 'email_dup', 'email_duplicate']) {
+    const candidates = [
+      makeEl({ name: marker, id: marker, type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'Email' }),
+    ];
+    const page = makeResolvePage(candidates);
+    const result = await resolveField(page, 'input[name="email"]', 'relay@mask.example');
+    assert.equal(result, null, `marker "${marker}" must abstain (JSDoc advertises dup(licate))`);
+  }
+});
+
+// Carve-out — a version suffix (v2) is NOT a duplicate marker. The renamed
+// PRIMARY must still resolve (this is the regression the guard must not cause).
+test('confirm-guard: version suffix v2 is NOT treated as a duplicate marker', async () => {
+  const candidates = [
+    makeEl({ name: 'given_name_v2', type: 'text', tagName: 'INPUT', autocomplete: 'given-name', placeholder: 'Given name' }),
+  ];
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="firstName"]', 'Jane');
+  assert.ok(result !== null, 'a v2-renamed primary must still resolve (not falsely abstained)');
+  assert.equal(result._resolvedEl, candidates[0]);
+});
+
+// ─── 14. LOW — deriveIntent snake_case / dash recall ─────────────────────────
+
+test('deriveIntent: full_name (snake_case) → fullName', () => {
+  assert.equal(deriveIntent('input[name="full_name"]', ''), 'fullName');
+});
+
+test('deriveIntent: user_email (snake_case, empty value) → email', () => {
+  // value is empty to isolate the selector path — \bemail\b would miss because
+  // `_` is a word char; substring match catches it.
+  assert.equal(deriveIntent('input[name="user_email"]', ''), 'email');
+});
+
+test('deriveIntent: customer_email_addr (substring) → email', () => {
+  assert.equal(deriveIntent('input[name="customer_email_addr"]', ''), 'email');
+});
+
+test('deriveIntent: first-name (dash) → firstName', () => {
+  assert.equal(deriveIntent('input[name="first-name"]', ''), 'firstName');
+});
+
+test('deriveIntent: zip_code (snake_case) → zip', () => {
+  assert.equal(deriveIntent('input[name="zip_code"]', ''), 'zip');
+});
+
+test('deriveIntent: username still excluded from fullName (guard intact)', () => {
+  assert.equal(deriveIntent('input[name="username"]', ''), 'generic');
+});
+
+// ─── 15. MEDIUM — snapshot-consistent selection (TOCTOU) ─────────────────────
+//
+// The winner is tagged with a data-* marker INSIDE the scoring evaluate and is
+// located by that marker, not re-selected by numeric index. A DOM mutation that
+// occurs after scoring (e.g. a node inserted ahead of the winner) therefore
+// cannot redirect the fill to a different element. With the OLD design, nth(0)
+// after a prepended node would resolve the wrong element.
+//
+// Mock-fidelity note: this mock cannot reproduce real Playwright's full DOM, so
+// it models the race by mutating the candidate array AFTER the scoring evaluate
+// returns but BEFORE the fill locator resolves. Because the production fix binds
+// the locator to the marker (carried ON the element object), the fill follows
+// the originally-scored element through the mutation. A pure-index design would
+// instead follow the index into the mutated array — that divergence IS the race.
+
+test('TOCTOU: winner is bound by marker, survives a node prepended after scoring', async () => {
+  const winner = makeEl({ name: 'email', id: 'email', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'Email' });
+  const candidates = [winner];
+
+  const page = makeResolvePage(candidates, {
+    // After scoring tags `winner`, an attacker/SPA prepends a fresh input at
+    // index 0. A by-index reselect would now fill THIS decoy, not the winner.
+    mutate(arr) {
+      arr.unshift(makeEl({ name: 'decoy', id: 'decoy', type: 'text', tagName: 'INPUT' }));
+    },
+  });
+
+  const result = await resolveField(page, 'input[name="email"]', 'relay@mask.example');
+  assert.ok(result !== null, 'should resolve the email field');
+  // The marker rides on the winner element object, so the fill targets `winner`,
+  // NOT the decoy now sitting at index 0.
+  assert.equal(result._resolvedEl, winner, 'fill must follow the tagged winner, not index 0 after mutation');
+  assert.notEqual(result._resolvedEl.name, 'decoy', 'must not bind to the post-scoring decoy node');
+});
+
+test('TOCTOU: exactly one element is tagged as the winner', async () => {
+  const a = makeEl({ name: 'first_name', type: 'text', tagName: 'INPUT', autocomplete: 'given-name', placeholder: 'First name' });
+  const b = makeEl({ name: 'last_name', type: 'text', tagName: 'INPUT', autocomplete: 'family-name', placeholder: 'Last name' });
+  const candidates = [a, b];
+  const page = makeResolvePage(candidates);
+  await resolveField(page, 'input[name="firstName"]', 'Jane');
+  const tagged = candidates.filter(el => el.hasAttribute('data-aidr-resolve'));
+  assert.equal(tagged.length, 1, 'exactly one winner must be tagged');
+  assert.equal(tagged[0], a, 'the firstName field is the tagged winner');
+});
+
+test('TOCTOU: a stale marker from a prior run is cleared before scoring', async () => {
+  const winner = makeEl({ name: 'email', id: 'email', type: 'email', tagName: 'INPUT', autocomplete: 'email', placeholder: 'Email' });
+  const stale = makeEl({ name: 'old', id: 'old', type: 'text', tagName: 'INPUT' });
+  stale.setAttribute('data-aidr-resolve', '1'); // leftover from an aborted run
+  const candidates = [stale, winner];
+  const page = makeResolvePage(candidates);
+  const result = await resolveField(page, 'input[name="email"]', 'relay@mask.example');
+  assert.equal(result._resolvedEl, winner, 'stale marker must be cleared so the new winner binds');
+  assert.ok(!stale.hasAttribute('data-aidr-resolve'), 'stale marker must be removed');
+});
+
+// ─── 16. Observability — abstain emits one console.warn (new path only) ──────
+
+test('observability: abstain on generic intent emits one console.warn', async () => {
+  const warns = [];
+  const orig = console.warn;
+  console.warn = (...a) => warns.push(a.join(' '));
+  try {
+    const page = makeResolvePage([makeEl({ name: 'address', type: 'text', tagName: 'INPUT' })]);
+    await resolveField(page, 'input[name="address"]', '123 Main St');
+  } finally {
+    console.warn = orig;
+  }
+  assert.equal(warns.length, 1, 'exactly one warn on abstain');
+  assert.match(warns[0], /field-resolver: no match for intent=generic selector=input\[name="address"\]/);
+});
+
+test('observability: abstain on below-threshold emits one console.warn with the intent', async () => {
+  const warns = [];
+  const orig = console.warn;
+  console.warn = (...a) => warns.push(a.join(' '));
+  try {
+    const page = makeResolvePage([makeEl({ name: 'contact', type: 'text', tagName: 'INPUT', placeholder: 'mail' })]);
+    await resolveField(page, 'input[name="email"]', 'user@example.com');
+  } finally {
+    console.warn = orig;
+  }
+  assert.equal(warns.length, 1, 'one warn when no candidate clears threshold');
+  assert.match(warns[0], /intent=email/);
+});
+
+test('observability: a successful resolve does NOT warn', async () => {
+  const warns = [];
+  const orig = console.warn;
+  console.warn = (...a) => warns.push(a.join(' '));
+  try {
+    const page = makeResolvePage([makeEl({ name: 'email', type: 'email', tagName: 'INPUT', autocomplete: 'email' })]);
+    const result = await resolveField(page, 'input[name="email"]', 'user@example.com');
+    assert.ok(result !== null);
+  } finally {
+    console.warn = orig;
+  }
+  assert.equal(warns.length, 0, 'no warn on a successful match');
+});
+
+// ─── 17. LOW — SIGNAL_WEIGHTS is a real exported constant (DRY) ───────────────
+
+test('SIGNAL_WEIGHTS: exported, frozen, has the documented weights', () => {
+  assert.equal(typeof SIGNAL_WEIGHTS, 'object');
+  assert.ok(Object.isFrozen(SIGNAL_WEIGHTS), 'weights should be frozen (single source of truth)');
+  assert.equal(SIGNAL_WEIGHTS.typeMatch, 4);
+  assert.equal(SIGNAL_WEIGHTS.autocomplete, 3);
+  assert.equal(SIGNAL_WEIGHTS.exactName, 3);
+  assert.equal(SIGNAL_WEIGHTS.substring, 2);
+});
+
+test('scoreElement closure-free: serialized scorer references no module-level free variables', () => {
+  // The scorer is serialized via .toString() and rebuilt with new Function inside
+  // page.evaluate. If it closed over SIGNAL_WEIGHTS / MATCH_THRESHOLD / a regex,
+  // those references would be undefined in the browser. Guard: the source must
+  // not name any module-level identifier — it takes weights + negativeMarkerSrc
+  // as parameters instead.
+  const fnResolverSrc = resolveField.toString();
+  // Pull the scorer's serialized source the way resolveField does (scoreElement
+  // is private; assert via the public behaviour that it runs under new Function).
+  // Direct guard: resolveField passes weights + negativeMarkerSrc into evaluate.
+  assert.match(fnResolverSrc, /weights:\s*SIGNAL_WEIGHTS/, 'weights are passed as an arg, not closed over');
+  assert.match(fnResolverSrc, /negativeMarkerSrc:\s*NEGATIVE_MARKER_SRC/, 'marker source passed as an arg');
+});
+
+// ─── Falsification check: verify tests go RED without the resolver ────────────
+// Sections 6 and 7 assert state.resolverCalled=true — removing the resolveField
+// integration from fillForm makes them fail. The confirm-guard matrix (13) goes
+// RED if the negative-signal penalty is removed (confirm fields would score high
+// and resolve). The TOCTOU tests (15) go RED if selection reverts to nth(index).
+// The deriveIntent recall tests (14) go RED if the snake/dash fragments are
+// removed (\bname\b/\bemail\b miss snake_case). The observability tests (16) go
+// RED if warnNoMatch is dropped. The threshold/score tests fail if
+// MATCH_THRESHOLD is 0 or scoreElement is identity-zeroed.

--- a/test/forms-bugs.test.js
+++ b/test/forms-bugs.test.js
@@ -117,14 +117,18 @@ test('fillForm does not throw when formFields key contains regex metacharacters'
     }),
     getByLabel: (re) => {
       getByLabelCalled = true;
-      // Should be called without throwing
+      // Should be called without throwing. Real Playwright Locator exposes
+      // count(); fillForm reads it to gate filled=true (silent-miss → resolver).
       return {
+        count: async () => 0, // label miss → fill skipped, resolver may run
         first: () => ({
           fill: async () => {},
           catch: async () => {},
         }),
       };
     },
+    // Resolver fallback round-trip after a label miss — no-op stub returns no match.
+    evaluate: async () => ({ found: false }),
   };
 
   let error = null;
@@ -156,11 +160,14 @@ test('fillForm getByLabel fallback uses escaped regex so metachar does not cause
     getByLabel: (re) => {
       regexesCreated.push(re);
       return {
+        count: async () => 0, // label miss → fill skipped (regex still recorded above)
         first: () => ({
           fill: async () => {},
         }),
       };
     },
+    // Resolver fallback round-trip after a label miss — no-op stub returns no match.
+    evaluate: async () => ({ found: false }),
   };
 
   await fillForm(page, formFields);


### PR DESCRIPTION
# feat(forms): semantic field-resolver fallback for missed CSS selectors

Closes: #6

## Summary

- **New `lib/field-resolver.js`**: pure semantic matcher. Derives field intent from the missed selector + value; scores visible inputs by 7 independent signals (type, name/id, placeholder, aria-label, label text, autocomplete); returns the best candidate above `MATCH_THRESHOLD = 5`; ties abstain.
- **`lib/forms.js`**: secondary fallback path in `fillForm()`. Fires only on miss, after the existing `getByLabel` primary fallback. The primary fallback now flags the field filled **only when `getByLabel` actually matched ≥1 element** — a silent label miss (renamed attribute + no `<label>`) no longer short-circuits the resolver. Happy path (exact selector hit) is completely unchanged.
- **`test/field-resolver.test.js`**: 54 tests, all green.
- **`test/field-resolver.browser.test.js`**: opt-in real-browser integration (6 scenarios, headless Chromium). Self-skips under the default `node --test test/*.test.js` glob via `describe(..., { skip: !process.env.AIDR_BROWSER_TESTS })` — reports `# SKIP`, exit 0, no worker warning; runs only with `AIDR_BROWSER_TESTS=1`. CI behavior verified clean.

## The provable gap this closes

The existing fallback in `fillForm()` (lines 133–141 in `lib/forms.js`) uses `extractKeyword()` to pull the label keyword from the selector:

```js
function extractKeyword(selector) {
  const m = selector.match(/\*="([^"]+)"/);  // matches ONLY *="..." substring selectors
  return m ? m[1] : null;
}
```

Every explicit broker uses **exact** attribute selectors — no `*=` pattern:

| Broker | Selector |
|--------|----------|
| Spokeo | `input[name="email"]` |
| WhitePages | `input[name="name"]`, `input[name="email"]` |
| BeenVerified | `input[name="firstName"]`, `input[name="lastName"]` |
| Radaris | `input[name*="first" i]` (keyword = `"first"` → `AMBIGUOUS_KEYWORDS` → blocked) |
| ... | ... |

For `input[name="email"]`: `extractKeyword` → `null` → fallback **never fires**.  
For `input[name*="first" i]`: `extractKeyword` → `"first"` → `isAmbiguousKeyword("first")` → `true` → fallback **never fires**.

Before this PR: when a broker renames `email` to `email_address` or `firstName` to `given_name`, the field is silently skipped with no fill. After this PR: the resolver detects the email/firstName intent from the original selector and finds the renamed field by autocomplete + placeholder + type signals.

## Relationship to WP-S7

WP-S7 (`docs/plans/2026-05-19-stability-features.md`) adds drift **detection**: rolling history tracking + `drifted` confidence label + end-of-run summary. It does not recover. This PR adds the **recovery layer** that WP-S7 detection logically calls for:

- Detection (WP-S7): "Spokeo has failed 3+ times — selector may have drifted"
- Recovery (this PR): "Primary selector missed → try semantic resolution → if confident, fill anyway"

WP-S7 shipped in the last upstream commit (`06f8db2`). This PR is the natural follow-on.

## Before / after

**Before** — broker renames `firstName` → `given_name_v2`:
```
selector miss: input[name="firstName"]
extractKeyword → null
→ no fallback fired
→ field left empty, opt-out likely fails
```

**After**:
```
selector miss: input[name="firstName"]
extractKeyword → null          (primary path still skips)
→ resolveField("input[name=\"firstName\"]", "Jane")
→ intent = firstName
→ scores candidates:
    given_name_v2  autocomplete=given-name (3) + placeholder="Given name" (2) = 5 ✓
    family_name_v2 autocomplete=family-name (3) + placeholder="Family name" (2) → no match
→ fills given_name_v2 with "Jane"
```

## Design constraints

- **Zero new dependencies** — pure JS, no embeddings, no ML.
- **Conservative threshold** — MATCH_THRESHOLD = 5 requires at least two independent signals. A single weak match (placeholder substring alone = 2 pts) does not fill.
- **Tie abstain** — when two candidates share the exact top score, the resolver returns `null`. Wrong fill > no fill.
- **Additive, not destructive** — the happy path (exact selector hit, lines 116–131) is completely unchanged. The resolver is pure opt-in-on-miss.

## Test evidence

```
$ node --test test/field-resolver.test.js
# tests 54
# pass 54
# fail 0

$ npm test
# tests 1129
# pass 1129
# fail 0
```

Tests cover: exact-selector miss (input[name="email"]), ambiguous-keyword kill-switch bypass (input[name*="name"]), **silent `getByLabel` miss (renamed attr + no `<label>`) → resolver still fires**, `getByLabel` hit still short-circuits the resolver (no double-fill), placeholder-only fields, aria-only fields, renamed attributes (broker DOM change), tie abstain, threshold boundary, confirm/duplicate PII guard matrix (incl. `dup`/`duplicate` parity), TOCTOU marker-bound selection, happy-path no-invoke, and observability warns.

**Red-on-revert evidence**:
- Reverting the `getByLabel().count()` gate in `fillForm()` (back to unconditional `filled = true`) makes `fillForm: resolver FIRES when CSS miss + getByLabel silently misses` fail — `resolverCalled` stays `false` because the field is wrongly flagged filled.
- Removing the secondary fallback block from `fillForm()` makes the `fillForm: secondary resolver fires...` tests fail.
- Weakening the negative-marker alternation from `dup(?:licate)?` back to `dup` makes `confirm-guard: dup AND duplicate markers both abstain` fail (`duplicate_email` becomes a fill target).
- Removing `resolveField()` from `field-resolver.js` exports breaks the resolver tests at import time.

## Test plan

- [x] Run `npm test` — expect 1129 pass, 0 fail
- [x] **Real-browser smoke (empirical — headless Chromium 148.0.7778.96)**: 6 scenarios run against `page.setContent()` fixture HTML in a real Chromium process via `AIDR_BROWSER_TESTS=1 node --test test/field-resolver.browser.test.js` — all PASS. The `new Function` scorer serialisation, the `data-aidr-resolve` marker binding, and `page.locator().inputValue()` DOM reads all execute in a real browser, not a mock:
  - **S1 PASS**: `email_address` field (renamed from `email`, type=email + autocomplete=email + placeholder) filled with `test@example.com`. Resolver recovered via real `page.evaluate`.
  - **S1b PASS**: `given_name` field (renamed from `first_name`, autocomplete=given-name) filled with `Alice`. Resolver recovered via real `page.evaluate`.
  - **S2 PASS**: `user_email_addr` (primary) filled with `user@example.com`; `confirm_email` stayed `""` — confirm-guard held in real browser.
  - **S3 PASS**: opaque primary (`usr_em`, no type/autocomplete/placeholder) + readable `confirm_email` → resolver abstained; both fields empty. CASE A fail-safe confirmed.
  - **S4 PASS**: exact selector `input[name="email"]` filled directly; `data-aidr-resolve` marker absent — resolver was never invoked.
  - **S5 PASS**: marker lifecycle verified — absent before resolve, count=1 after `resolveField()`, absent after `clearResolveMarker()`. Fill via marker produced correct value.
- [x] Confirm happy-path brokers (with working selectors) show no change in behavior — resolver `page.evaluate` is never called
- [x] Run with `--only Radaris` or `--only Spokeo` against a real browser to confirm opt-out still completes

## Files changed

- `lib/field-resolver.js` — new semantic matcher; negative-marker guard covers `dup`/`duplicate` parity and is applied to free text intentionally (confirm-field PII guard)
- `lib/forms.js` — secondary fallback block in `fillForm()`; primary `getByLabel` fallback gated on `count() > 0` so a silent label miss reaches the resolver; 1 new `require`
- `test/field-resolver.test.js` — 54 tests (mock-based, default fast suite)
- `test/field-resolver.browser.test.js` — 6 real-browser integration tests (opt-in, `AIDR_BROWSER_TESTS=1`); skips silently in default `npm test`
- `test/forms-bugs.test.js` — +8/−1 only: the pre-existing `getByLabel` metachar tests get a `count()` mock + a no-op resolver `evaluate` stub, because `fillForm()` now reads `getByLabel().count()` to gate `filled`. Keeps the existing suite green; no production change to the bugs this file already covered.
