### PR TITLE
Fix dashboard path resolution and missing express install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ config.json
 config.json.enc
 state.json
 state.json.bak
+state.json.checkpoint
 state.json.tmp
 state.json.lock
 serp-history.json

--- a/bin/aidr.js
+++ b/bin/aidr.js
@@ -28,7 +28,7 @@ function printVersion() {
 }
 
 function spawnNode(resolved) {
-  const cwd = resolved.cwd === 'dashboard' ? path.join(ROOT, 'dashboard') : ROOT;
+  const cwd = ROOT;
   const env = { ...process.env };
   let onSpawn = null;
 

--- a/install.sh
+++ b/install.sh
@@ -35,6 +35,17 @@ echo ""
 echo "Installing dependencies (npm ci)..."
 npm ci
 
+# 3b. Install the dashboard's own dependencies (it's a separate package).
+if [ -f "dashboard/package.json" ]; then
+  echo ""
+  echo "Installing dashboard dependencies..."
+  if [ -f "dashboard/package-lock.json" ]; then
+    npm ci --prefix dashboard
+  else
+    npm install --prefix dashboard
+  fi
+fi
+
 # 4. Install the Chromium browser Playwright drives.
 echo ""
 echo "Installing the Chromium browser (npx playwright install chromium)..."

--- a/state.json.checkpoint
+++ b/state.json.checkpoint
@@ -1,1 +1,0 @@
-Experian (marketing)

--- a/state.json.checkpoint
+++ b/state.json.checkpoint
@@ -1,0 +1,1 @@
+Experian (marketing)


### PR DESCRIPTION
-added state.json.checkpoint to gitignore so future contributors don't accidentally push theirs
-encountered issues with starting dashboard. the first was that "aidr dashboard" resolved to ~/dashboard/dashboard/server.js, so that path was fixed. once that path was fixed, i ran into an error stating the browser dependency wasn't installed, so modified the install.sh file to account for installing it if it isnt already